### PR TITLE
Allow ERB in key_vault.yml to allow for ENV variables

### DIFF
--- a/lib/key_vault.rb
+++ b/lib/key_vault.rb
@@ -18,7 +18,7 @@ module KeyVault
     end
 
     def values
-      @values ||= YAML.load(IO.read(Rails.root + "config/key_vault.yml")).symbolize_keys
+      @values ||= YAML.load(ERB.new(IO.read(Rails.root + "config/key_vault.yml")).result).symbolize_keys
     end
   end
 end

--- a/spec/key_vault_spec.rb
+++ b/spec/key_vault_spec.rb
@@ -30,6 +30,7 @@ describe KeyVault do
     before do
       Rails.stub root: '/tmp/'
       FileUtils.mkdir '/tmp/config'
+      ENV['my-super-secret'] = 'super_super_secret'
     end
 
     after do
@@ -38,10 +39,11 @@ describe KeyVault do
 
     it 'reads key_vault.yml in the rails config folder' do
       File.open('/tmp/config/key_vault.yml', 'w') do |f|
-        f.puts({ session_secret: 'super_secret' }.to_yaml)
+        f.puts({ session_secret: 'super_secret', super_secret: "<%= ENV['my-super-secret'] %>" }.to_yaml)
       end
 
       KeyVault.values[:session_secret].should == 'super_secret'
+      KeyVault.values[:super_secret].should == 'super_super_secret'
     end
   end
 end


### PR DESCRIPTION
Not sure if this gem is actually maintained anymore however;

Allow the addition of ERB in the `key_vault.yml` file so ENV variables can be used.
